### PR TITLE
expose SaslCredentials.mechanism for ldapserver SASL support

### DIFF
--- a/message/bind_request.go
+++ b/message/bind_request.go
@@ -19,6 +19,10 @@ func (request *BindRequest) AuthenticationSimple() OCTETSTRING {
 	return request.Authentication().(OCTETSTRING)
 }
 
+func (request *BindRequest) AuthenticationSasl() SaslCredentials {
+	return request.Authentication().(SaslCredentials)
+}
+
 func (request *BindRequest) AuthenticationChoice() string {
 	switch request.Authentication().(type) {
 	case OCTETSTRING:

--- a/message/extended_response.go
+++ b/message/extended_response.go
@@ -12,11 +12,6 @@ func (extended *ExtendedResponse) SetResponseName(name LDAPOID) {
 	extended.responseName = &name
 }
 
-func (extended *ExtendedResponse) SetResponseValue(value string) {
-	oct := OCTETSTRING(value)
-	extended.responseValue = &oct
-}
-
 func readExtendedResponse(bytes *Bytes) (ret ExtendedResponse, err error) {
 	err = bytes.ReadSubBytes(classApplication, TagExtendedResponse, ret.readComponents)
 	if err != nil {

--- a/message/extended_response.go
+++ b/message/extended_response.go
@@ -12,6 +12,11 @@ func (extended *ExtendedResponse) SetResponseName(name LDAPOID) {
 	extended.responseName = &name
 }
 
+func (extended *ExtendedResponse) SetResponseValue(value string) {
+	oct := OCTETSTRING(value)
+	extended.responseValue = &oct
+}
+
 func readExtendedResponse(bytes *Bytes) (ret ExtendedResponse, err error) {
 	err = bytes.ReadSubBytes(classApplication, TagExtendedResponse, ret.readComponents)
 	if err != nil {

--- a/message/sasl_credentials.go
+++ b/message/sasl_credentials.go
@@ -2,6 +2,10 @@ package message
 
 import "fmt"
 
+func (authentication SaslCredentials) Mechanism() LDAPString {
+        return authentication.mechanism
+}
+
 //
 //        SaslCredentials ::= SEQUENCE {
 //             mechanism               LDAPString,


### PR DESCRIPTION
This relates to [vjeantet/ldapserver/issues/9](https://github.com/vjeantet/ldapserver/issues/9).

For SASL support, [ldapserver](https://github.com/vjeantet/ldapserver) would need to determine what SASL mechanism -- for example, `EXTERNAL` or `GSSAPI` -- is indicated in the request.  This change exposes the private `SaslCredentials.mechanism` struct field via an exported method, `SaslCredentials.Mechanism()`, which accepts no arguments and returns the relevant `LDAPString` value.

EDIT: On the same point, we need to add the `BindRequest.SaslAuthentication` helper method to allow access to the underlying instance of `SaslCredentials`, as we're already doing for simple binds. I've updated this PR accordingly.

Thoughts (from anyone) are welcome.